### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-CLongTimer                     KEYWORD1
+CLongTimer	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-start                          KEYWORD2
-stop                           KEYWORD2
-tick                           KEYWORD2
-set                            KEYWORD2
-elapsed                        KEYWORD2
-enabled                        KEYWORD2
-event                          KEYWORD2
+start	KEYWORD2
+stop	KEYWORD2
+tick	KEYWORD2
+set	KEYWORD2
+elapsed	KEYWORD2
+enabled	KEYWORD2
+event	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords